### PR TITLE
fix post-aggregation

### DIFF
--- a/src/processing/sakura_thread.cpp
+++ b/src/processing/sakura_thread.cpp
@@ -508,6 +508,7 @@ SakuraThread::processForEach(ForEachBranching* forEachItem,
     else
     {
         result = m_interface->m_queue->spawnParallelSubtreesLoop(forEachItem->content,
+                                                                 forEachItem->values,
                                                                  filePath,
                                                                  m_hierarchy,
                                                                  m_parentValues,
@@ -574,6 +575,7 @@ SakuraThread::processFor(ForBranching* forItem,
     else
     {
         result = m_interface->m_queue->spawnParallelSubtreesLoop(forItem->content,
+                                                                 forItem->values,
                                                                  filePath,
                                                                  m_hierarchy,
                                                                  m_parentValues,

--- a/src/processing/subtree_queue.cpp
+++ b/src/processing/subtree_queue.cpp
@@ -53,6 +53,7 @@ SubtreeQueue::addSubtreeObject(SubtreeObject* newObject)
  * @brief run a parallel loop
  *
  * @param subtree subtree, which should be executed multiple times by multiple threads
+ * @param postProcessing post-aggregation information
  * @param filePath path of the file, where the subtree belongs to
  * @param hierarchy actual hierarchy for terminal output
  * @param parentValues data-map with parent-values
@@ -66,6 +67,7 @@ SubtreeQueue::addSubtreeObject(SubtreeObject* newObject)
  */
 bool
 SubtreeQueue::spawnParallelSubtreesLoop(SakuraItem* subtree,
+                                        ValueItemMap postProcessing,
                                         const std::string &filePath,
                                         const std::vector<std::string> &hierarchy,
                                         DataMap &parentValues,
@@ -108,7 +110,7 @@ SubtreeQueue::spawnParallelSubtreesLoop(SakuraItem* subtree,
     for(uint64_t i = startPos; i < endPos; i++)
     {
         std::string errorMessage = "";
-        if(fillInputValueItemMap(subtree->values,
+        if(fillInputValueItemMap(postProcessing,
                                  spawnedObjects.at(static_cast<uint32_t>(i))->items,
                                  errorMessage) == false)
         {
@@ -119,7 +121,7 @@ SubtreeQueue::spawnParallelSubtreesLoop(SakuraItem* subtree,
         }
     }
 
-    overrideItems(parentValues, subtree->values, ONLY_EXISTING);
+    overrideItems(parentValues, postProcessing, ONLY_EXISTING);
 
     clearSpawnedObjects(spawnedObjects);
 

--- a/src/processing/subtree_queue.h
+++ b/src/processing/subtree_queue.h
@@ -132,6 +132,7 @@ public:
                                const uint64_t endPos = 1,
                                const uint64_t startPos = 0);
     bool spawnParallelSubtreesLoop(SakuraItem* subtree,
+                                   ValueItemMap postProcessing,
                                    const std::string &filePath,
                                    const std::vector<std::string> &hierarchy,
                                    DataMap &parentValues,


### PR DESCRIPTION
## Description

fix post-aggregation of parallel for loops

## Related Issues

- #69 

## How it was tested?

```
["test-post-aggregation"]
- input = ["asdf", "xyz", "poi"]
- result = []
- tempValue = ""

parallel_for(value : input)
- result = result.append(tempValue)
{
    item_update("update value")
    - tempValue = ">{{value}}<"
}

print("print result")
- result = result
```