### PR TITLE
updates for tagging 0.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.1] - 2020-09-26
+
+### Fixed
+- fixed name-conflicts in blossom- and subtree-calls by adding new validation in parser
+- fix resource- and subtree-calls, which had failed when they had no output
+
+
 ## [0.5.0] - 2020-09-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Documentation for latest master-version:
 
 https://gitlab.com/kitsudaiki/libKitsunemimiSakuraLang-Documentation/builds/artifacts/master/browse?job=build
 
-Documentation version 0.5.0 (only syntax-documentation):
+Documentation version 0.5.1 (only syntax-documentation):
 
-https://files.kitsunemimi.moe/docs/libKitsunemimiSakuraLang-Documentation_0_5_0.pdf
+https://files.kitsunemimi.moe/docs/libKitsunemimiSakuraLang-Documentation_0_5_1.pdf
 
 
 ## Build

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT -= qt core gui
 TARGET = KitsunemimiSakuraLang
 CONFIG += c++14
 TEMPLATE = lib
-VERSION = 0.5.0
+VERSION = 0.5.1
 
 LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
 LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon


### PR DESCRIPTION
## Description

updates for tagging 0.5.1

## Related Issues

- #82 

## How it was tested?

- ci-pipelines and manually tests in SakuraTree
