### PR TITLE
remove required-flag from output-field-registration

### DIFF
--- a/include/libKitsunemimiSakuraLang/blossom.h
+++ b/include/libKitsunemimiSakuraLang/blossom.h
@@ -78,7 +78,7 @@ protected:
     bool allowUnmatched = false;
 
     bool registerInputField(const std::string &name, const bool required);
-    bool registerOutputField(const std::string &name, const bool required);
+    bool registerOutputField(const std::string &name);
 
 private:
     friend SakuraThread;

--- a/src/blossom.cpp
+++ b/src/blossom.cpp
@@ -59,15 +59,13 @@ Blossom::registerInputField(const std::string &name,
  * @brief register output field for validation of incoming messages
  *
  * @param name name of the filed to identifiy value
- * @param required false, to make field optional, true to make it required
  *
  * @return false, if already name already registered, else true
  */
 bool
-Blossom::registerOutputField(const std::string &name,
-                             const bool required)
+Blossom::registerOutputField(const std::string &name)
 {
-    return registerField(name, OUTPUT_TYPE, required);
+    return registerField(name, OUTPUT_TYPE, false);
 }
 
 /**

--- a/tests/functional_tests/standalone_blossom.cpp
+++ b/tests/functional_tests/standalone_blossom.cpp
@@ -15,7 +15,7 @@ StandaloneBlossom::StandaloneBlossom(Interface_Test* sessionTest)
     registerInputField("input", true);
     registerInputField("should_fail", false);
 
-    registerOutputField("output", true);
+    registerOutputField("output");
 }
 
 bool

--- a/tests/functional_tests/test_blossom.cpp
+++ b/tests/functional_tests/test_blossom.cpp
@@ -14,7 +14,7 @@ TestBlossom::TestBlossom(Interface_Test* sessionTest)
     m_sessionTest = sessionTest;
     registerInputField("input", true);
     registerInputField("should_fail", false);
-    registerOutputField("output", true);
+    registerOutputField("output");
 }
 
 bool

--- a/tests/memory_leak_tests/standalone_blossom.cpp
+++ b/tests/memory_leak_tests/standalone_blossom.cpp
@@ -15,7 +15,7 @@ StandaloneBlossom::StandaloneBlossom(Interface_Test* sessionTest)
     registerInputField("input", true);
     registerInputField("should_fail", false);
 
-    registerOutputField("output", true);
+    registerOutputField("output");
 }
 
 bool

--- a/tests/memory_leak_tests/test_blossom.cpp
+++ b/tests/memory_leak_tests/test_blossom.cpp
@@ -14,12 +14,12 @@ TestBlossom::TestBlossom(Interface_Test* sessionTest)
     m_sessionTest = sessionTest;
     registerInputField("input", true);
     registerInputField("should_fail", false);
-    registerOutputField("output", true);
+    registerOutputField("output");
 }
 
 bool
 TestBlossom::runTask(BlossomLeaf &blossomLeaf,
-                     const DataMap* context,
+                     const DataMap*,
                      BlossomStatus &status,
                      ErrorContainer &error)
 {


### PR DESCRIPTION
## Description

remove required-flag from output-field-registration

## Related Issues

- #131 

## How it was tested?

- ci-pipeline
